### PR TITLE
Update example to include needed permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,15 @@ your workflows removing the need of hardcoding credentials on your repos.
 
 ```yaml
 name: Pulumi
+
 on:
   push:
     branches:
       - master
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   up:
     name: Preview

--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ jobs:
           stack-name: org-name/stack-name
 ```
 
+> Note that specific permisions are required for the action to be able to request
+> an id-token. For more info see the [GitHub documentation](https://docs.github.com/en/actions/security-for-github-actions/security-hardening-your-deployments/about-security-hardening-with-openid-connect#adding-permissions-settings)
+
 This will check out the existing directory, then fetch a Pulumi access token
 for the `contoso` organization and run `pulumi preview`.
 


### PR DESCRIPTION
Fix https://github.com/pulumi/auth-actions/issues/47

Add required permissions to the example and include reference to required permissions to fetch the GitHub id-token