### PR TITLE
Add workflow for publishing immutable actions

### DIFF
--- a/.github/workflows/immutable-action.yml
+++ b/.github/workflows/immutable-action.yml
@@ -1,0 +1,23 @@
+name: "Publish Immutable Action Version"
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Publish
+        id: publish
+        uses: actions/publish-immutable-action@v0.0.4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
After this action is converted and migrated as a immutable action, this workflow will start publishing the actions in the new registry.