### PR TITLE
Remove mention to old admin scope for org tokens on oidc

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,6 @@ The action can be configured with the following arguments:
     according to the token type:
     - For personal access tokens: `user:USER_NAME`
     - For team access tokens: `team:TEAM_NAME`
-    - For organization access tokens, the `admin` scope can be set to request a token with admin privileges (the authorization policy should explicitly grant the increased permissions)
 
 - `token-expiration` (optional) - The token expiration in seconds requested. It 
     is up to the Pulumi authorization server to grant or reduce it.


### PR DESCRIPTION
We updated oidc issues to support roles for organization tokens. I am removing mention to the old standard/admin access level and admin scope support.