### PR TITLE
chore: Prepare v2.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## HEAD (Unreleased)
 
+**(none)**
+
+---
+
+## 2.0.0 (2026-05-29)
+
+- feat: Update action runtime to Node 24 (**breaking change**)
+  ([#59](https://github.com/pulumi/auth-actions/pull/59))
+- chore: Use `@pulumi/actions-helpers`
+  ([#54](https://github.com/pulumi/auth-actions/pull/54))
+- docs: Remove mention of old admin scope for org tokens on OIDC
+  ([#56](https://github.com/pulumi/auth-actions/pull/56))
 - fix: oauth url on windows
   ([#53](https://github.com/pulumi/auth-actions/pull/53))
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pulumi GitHub Auth Actions
 
-Pulumi's GitHub Auth Actions automatically generate and exchange GitHub's 
+Pulumi's GitHub Auth Actions automatically generates and exchanges GitHub's 
 OpenID Connect tokens for Pulumi Access Tokens, making them available to 
 your workflows and removing the need to hardcode credentials in your repos.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Pulumi GitHub Auth Actions
 
-Pulumi's GitHub Auth Actions automatically generates and exchanges GitHub's 
-OpenID Connect tokens by Pulumi Access Tokens, making them available for 
-your workflows removing the need of hardcoding credentials on your repos.
+Pulumi's GitHub Auth Actions automatically generate and exchange GitHub's 
+OpenID Connect tokens for Pulumi Access Tokens, making them available to 
+your workflows and removing the need to hardcode credentials in your repos.
 
 - [Documentation](https://www.pulumi.com/docs/pulumi-cloud/oidc/client/)
 
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: pulumi/auth-actions@v1
+      - uses: pulumi/auth-actions@v2
         with:
           organization: contoso
           requested-token-type: urn:pulumi:token-type:access_token:organization
@@ -35,7 +35,7 @@ jobs:
           stack-name: org-name/stack-name
 ```
 
-> Note that specific permisions are required for the action to be able to request
+> Note that specific permissions are required for the action to be able to request
 > an id-token. For more info see the [GitHub documentation](https://docs.github.com/en/actions/security-for-github-actions/security-hardening-your-deployments/about-security-hardening-with-openid-connect#adding-permissions-settings)
 
 This will check out the existing directory, then fetch a Pulumi access token

--- a/examples/pulumi.yaml
+++ b/examples/pulumi.yaml
@@ -18,7 +18,7 @@ jobs:
           cache: npm
 
       - name: Performing authentication 🔑
-        uses: pulumi/auth-actions@v1
+        uses: pulumi/auth-actions@v2
         with:
           organization: sample
           requested-token-type: urn:pulumi:token-type:access_token:organization

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pulumi-github-auth-action",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "main": "dist/index.js",
   "repository": "git@github.com:pulumi/auth-actions",
   "license": "Apache-2.0",


### PR DESCRIPTION
Housekeeping ahead of cutting the **v2.0.0** release from `main`.

The major version bump is driven by the **Node 24 runtime** change (#59), which is a breaking change for consumers.

## Changes
- **CHANGELOG.md**: Add a `2.0.0 (2026-05-29)` section collecting the changes since `1.0.0` (#59 Node 24 runtime, #54 `@pulumi/actions-helpers`, #56 OIDC docs, #53 windows oauth url fix); reset `HEAD (Unreleased)` to empty.
- **package.json**: Bump `version` `1.0.0` → `2.0.0`.
- **README.md** / **examples/pulumi.yaml**: Bump usage to `pulumi/auth-actions@v2`, fix the `permisions` typo, and tidy the intro wording.

## After merge
1. Wait for the `update_dist.yml` commit + status checks on `main`.
2. Draft & publish a `v2.0.0` GitHub Release targeting `main` (keep "Publish to Marketplace" checked).
3. `tag.yaml` will automatically create/move the floating `v2` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)