### PR TITLE
chore: Prepare v2.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## HEAD (Unreleased)
 
+**(none)**
+
+---
+
+## 2.1.0 (2026-05-29)
+
 - fix: Build with rollup instead of ncc to fix a load crash (`require is not
   defined in ES module scope`) that broke v2.0.0 for all consumers
   ([#63](https://github.com/pulumi/auth-actions/pull/63))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pulumi-github-auth-action",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "main": "dist/index.js",
   "repository": "git@github.com:pulumi/auth-actions",
   "license": "Apache-2.0",


### PR DESCRIPTION
Release prep for **v2.1.0**, which ships the v2 load-crash fix (#63).

- `package.json`: bump version `2.0.0` → `2.1.0`
- `CHANGELOG.md`: add `2.1.0` section (rollup build fix) and reset `HEAD (Unreleased)`

After merge, I'll publish the `v2.1.0` GitHub release; the `tag.yaml` workflow will move the `v2` major tag to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)